### PR TITLE
Fix onboarding loop by moving session sync to app level

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -5,60 +5,58 @@ import Login from './pages/Login'
 import Onboarding from './pages/Onboarding'
 import Dashboard from './pages/Dashboard'
 
-// Wrapper that handles post-login redirect logic
+// Guards a route: checks onboarding status and redirects accordingly.
+// Session is always established before this runs (see AppRoutes sync).
 function AuthGate({ children, requireOnboarded }) {
-  const { authenticated, ready, getAccessToken } = usePrivy()
+  const { authenticated, ready } = usePrivy()
   const [checking, setChecking] = useState(true)
   const [onboardingComplete, setOnboardingComplete] = useState(null)
 
   useEffect(() => {
     if (!ready) return
-    if (!authenticated) {
-      setChecking(false)
-      return
-    }
+    if (!authenticated) { setChecking(false); return }
 
-    async function loadProfile() {
-      try {
-        let res = await fetch('/api/user/profile', { credentials: 'include' })
-
-        // Session expired or missing — re-sync the Privy token then retry
-        if (res.status === 401) {
-          const token = await getAccessToken()
-          await fetch('/auth/privy', {
-            method: 'POST',
-            credentials: 'include',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ token }),
-          })
-          res = await fetch('/api/user/profile', { credentials: 'include' })
-        }
-
-        const data = await res.json()
-        setOnboardingComplete(!!data.onboardingComplete)
-      } catch {
-        // leave onboardingComplete as null — will stay on loading
-      } finally {
-        setChecking(false)
-      }
-    }
-
-    loadProfile()
+    fetch('/api/user/profile', { credentials: 'include' })
+      .then(r => r.json())
+      .then(data => setOnboardingComplete(!!data.onboardingComplete))
+      .catch(() => {})
+      .finally(() => setChecking(false))
   }, [authenticated, ready])
 
-  if (!ready || checking) return <div className="loading">Loading...</div>
+  if (!ready || checking) return <div style={s.loading}>Loading…</div>
   if (!authenticated) return <Navigate to="/" replace />
-
   if (requireOnboarded && !onboardingComplete) return <Navigate to="/onboarding" replace />
   if (!requireOnboarded && onboardingComplete) return <Navigate to="/dashboard" replace />
-
   return children
 }
 
+// Establishes the server session ONCE before any route is rendered.
+// This fixes the loop caused by Google OAuth returning to / with
+// authenticated=true but no server session yet.
 function AppRoutes() {
-  const { authenticated, ready } = usePrivy()
+  const { authenticated, ready, getAccessToken } = usePrivy()
+  const [sessionReady, setSessionReady] = useState(false)
 
-  if (!ready) return <div className="loading">Loading...</div>
+  useEffect(() => {
+    if (!ready) return
+    if (!authenticated) { setSessionReady(false); return }
+
+    getAccessToken()
+      .then(token =>
+        fetch('/auth/privy', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ token }),
+        })
+      )
+      .catch(() => {})
+      .finally(() => setSessionReady(true))
+  }, [authenticated, ready])
+
+  if (!ready || (authenticated && !sessionReady)) {
+    return <div style={s.loading}>Loading…</div>
+  }
 
   return (
     <Routes>
@@ -85,6 +83,19 @@ function AppRoutes() {
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
   )
+}
+
+const s = {
+  loading: {
+    minHeight: '100vh',
+    background: '#0f0f0f',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    color: '#555',
+    fontSize: '14px',
+    fontFamily: 'Arial, sans-serif',
+  },
 }
 
 export default function App() {

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -1,12 +1,9 @@
-import { useEffect, useState } from 'react'
-import { usePrivy, useLoginWithOAuth, useLoginWithEmail } from '@privy-io/react-auth'
-import { useNavigate } from 'react-router-dom'
+import { useState } from 'react'
+import { useLoginWithOAuth, useLoginWithEmail } from '@privy-io/react-auth'
 import Logo from '../components/Logo'
 
+// Session sync and post-login navigation are handled by AppRoutes in App.jsx.
 export default function Login() {
-  const { authenticated, ready, getAccessToken } = usePrivy()
-  const navigate = useNavigate()
-
   const [email, setEmail] = useState('')
   const [code, setCode] = useState('')
   const [emailError, setEmailError] = useState('')
@@ -18,38 +15,6 @@ export default function Login() {
   const sendingCode = emailState.status === 'sending-code'
   const submittingCode = emailState.status === 'submitting-code'
   const googleLoading = oauthState.status === 'loading'
-
-  // After Privy authenticates, sync session and navigate
-  useEffect(() => {
-    if (!ready || !authenticated) return
-
-    async function syncSession() {
-      try {
-        const token = await getAccessToken()
-        const res = await fetch('/auth/privy', {
-          method: 'POST',
-          credentials: 'include',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ token }),
-        })
-        const data = await res.json()
-        if (!data.success) return
-
-        const profileRes = await fetch('/api/user/profile', { credentials: 'include' })
-        const profile = await profileRes.json()
-
-        if (profile.onboardingComplete) {
-          navigate('/dashboard')
-        } else {
-          navigate('/onboarding')
-        }
-      } catch (err) {
-        console.error('Session sync failed:', err)
-      }
-    }
-
-    syncSession()
-  }, [authenticated, ready])
 
   async function handleSendCode(e) {
     e.preventDefault()

--- a/client/src/pages/Onboarding.jsx
+++ b/client/src/pages/Onboarding.jsx
@@ -1,5 +1,4 @@
 import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
 import { usePrivy } from '@privy-io/react-auth'
 
 async function syncSession(getAccessToken) {
@@ -34,7 +33,6 @@ const DURATIONS = [15, 30, 45, 60, 90]
 
 export default function Onboarding() {
   const { user, getAccessToken } = usePrivy()
-  const navigate = useNavigate()
 
   const [step, setStep] = useState(1)
   const [saving, setSaving] = useState(false)
@@ -84,7 +82,10 @@ export default function Onboarding() {
 
       const data = await res.json()
       if (data.success) {
-        navigate('/dashboard')
+        // Hard redirect so App re-runs session sync before reaching /dashboard.
+        // React Router navigation races with the session state; a full reload
+        // is reliable and matches what a manual refresh does.
+        window.location.href = '/dashboard'
       } else {
         setError('Something went wrong. Please try again.')
       }


### PR DESCRIPTION
Move server session establishment from Login.jsx into AppRoutes so it always runs once when authenticated, regardless of OAuth redirect path. Simplify AuthGate (no more 401 retry). Use window.location.href in Onboarding finish() so the page fully reloads before hitting /dashboard, matching the reliable 'refresh' path and avoiding the React Router session race condition.