### PR TITLE
Fix calendar day number visibility, legend styling, and weekday bug

### DIFF
--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -176,7 +176,7 @@ function CalendarView({ workouts, workcards }) {
               }}
               onClick={() => hasActivity && setSelectedKey(isSelected ? null : key)}
             >
-              <span className={styles.calDayNum} style={{ color: isToday ? '#ff1e00' : hasSubmitted ? '#fff' : hasPending ? '#888' : '#3a3a3a' }}>
+              <span className={styles.calDayNum} style={{ color: isToday ? '#ff1e00' : hasPending ? '#aaa' : '#fff' }}>
                 {day.getDate()}
               </span>
               {hasSubmitted && (

--- a/client/src/pages/Dashboard.module.css
+++ b/client/src/pages/Dashboard.module.css
@@ -126,8 +126,8 @@
   flex-wrap: wrap;
 }
 .legendItem {
-  color: #555;
-  font-size: 10px;
+  color: #ffffff;
+  font-size: 13px;
   display: flex;
   align-items: center;
   gap: 4px;
@@ -198,8 +198,9 @@
   transition: border-color 0.15s ease;
 }
 .calDayNum {
-  font-size: 12px;
-  font-weight: 600;
+  font-size: 14px;
+  font-weight: 700;
+  color: #ffffff;
 }
 .calScore {
   font-size: 9px;

--- a/client/src/pages/Workcards.jsx
+++ b/client/src/pages/Workcards.jsx
@@ -12,9 +12,10 @@ function ensureCheckedLength(checked, total) {
 
 function getWeekdayFromDate(dateStr) {
   if (!dateStr) return ''
-  const d = new Date(dateStr)
-  if (Number.isNaN(d.getTime())) return ''
-  return d.toLocaleDateString('en-US', { weekday: 'long' })
+  const [y, m, d] = dateStr.split('-').map(Number)
+  const date = new Date(y, m - 1, d)
+  if (Number.isNaN(date.getTime())) return ''
+  return date.toLocaleDateString('en-US', { weekday: 'long' })
 }
 
 export default function Workcards() {


### PR DESCRIPTION
- Calendar day numbers now white (#fff) with size 14px/700 weight
- Legend text color changed to white, font size increased to 13px
- Fix getWeekdayFromDate timezone bug: parse YYYY-MM-DD parts manually instead of new Date(str) which treats input as UTC and shifts day